### PR TITLE
Form data support

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,30 @@ hippie(app, swagger)
 //    Invalid format for parameter {body}, received: {"bogus":"post-body"}
 ```
 
+### Form Url-Encoded Parameters
+```js
+hippie(app, swagger)
+.form()
+.post('/users')
+.send({})
+.end(fn);
+
+// "username" is {required: true, in: formData} in swagger; throws:
+//    Missing required parameter in formData: username
+```
+
+### Multipart Forms
+```js
+hippie(app, swagger)
+.header('Content-Type','multipart/form-data')
+.send()
+.post('/users/upload')
+.end(fn);
+
+// "fileUpload" is {required: true, in: formData, type: file} in swagger; throws:
+//    Missing required parameter in formData: fileUpload
+```
+
 ## Troubleshooting
 
 The most common mistake is forgetting to dereference the swagger file:

--- a/lib/extra-parameters.js
+++ b/lib/extra-parameters.js
@@ -9,25 +9,41 @@ var settings = require('./settings');
  * Pass the {errorOnExtraParameters:false) option to disable
  *
  * @param  {Object} pathSpec - swagger path definition
- * @param  {Object} parameters - hash of request parameters
+ * @param  {Object} requestParams - hash of request parameters
  */
-module.exports = function validateNoExtraParams(pathSpec, parameters) {
+module.exports = function validateNoExtraParams(pathSpec, requestParams) {
   if(settings.get('errorOnExtraParameters') === false) return;
+
+  function throwParamNotFound(param) {
+    throw new Error('Parameter not mentioned in swagger spec: "' + param + '", available params: ' +
+      pathSpec.parameters.map(function(p) {
+        return p.name;
+      }).join(',')
+    );
+  }
 
   var pathSpecParamHash = pathSpec.parameters.reduce(function(hash, param) {
     hash[param.name] = param;
     return hash;
   }, {});
-  Object.keys(parameters).forEach(function(type) {
+  for(var type in requestParams) {
     if(type == 'header' && settings.get('errorOnExtraHeaderParameters') === false) return;
-    Object.keys(parameters[type]).forEach(function(param) {
-      if(!pathSpecParamHash[param]) {
-        throw new Error('Parameter not mentioned in swagger spec: "' + param + '", available params: ' +
-          pathSpec.parameters.map(function(p) {
-            return p.name;
-          }).join(',')
-        );
+
+    for(var param in requestParams[type]) {
+      if(param == 'body') {
+        //in the case of "body", the name superfluous & since there can only be one,
+        //it just needs to mentioned anywhere in the swagger file
+        var found = false;
+        for(var prop in pathSpecParamHash) {
+          if(pathSpecParamHash[prop].in == 'body') {
+            found = true;
+            break;
+          }
+        };
+        if(!found) throwParamNotFound(param);
+      } else if(!pathSpecParamHash[param]) {
+        throwParamNotFound(param);
       }
-    });
-  });
+    };
+  };
 }

--- a/lib/extra-parameters.js
+++ b/lib/extra-parameters.js
@@ -34,7 +34,7 @@ function handleFormData(requestFormData, specFormData) {
       }
     })
     if(!found) {
-      throwParamNotFound(qsKey);
+      throwParamNotFound(qsKey, 'formData');
     }
   }
 }
@@ -55,7 +55,7 @@ function handleMultipartFormData(multipartFormData, specFormData) {
     }
   });
   if(!found) {
-    throwParamNotFound(multipartFormData);
+    throwParamNotFound(multipartFormData, 'formData (expected type "file")');
   }
 }
 
@@ -71,8 +71,8 @@ function handleMultipartFormData(multipartFormData, specFormData) {
 module.exports = function validateNoExtraParams(pathSpec, requestParams) {
   if(settings.get('errorOnExtraParameters') === false) return;
 
-  throwParamNotFound = function(param) {
-    throw new Error('Parameter not mentioned in swagger spec: "' + param + '", available params: ' +
+  throwParamNotFound = function(param, location) {
+    throw new Error(location + ' parameter not mentioned in swagger spec: "' + param + '", available params: ' +
       pathSpec.parameters.map(function(p) {
         return p.name;
       }).join(',')
@@ -102,7 +102,7 @@ module.exports = function validateNoExtraParams(pathSpec, requestParams) {
       default:
         for(var param in requestParams[type]) {
           if(specParamsByName[param] === undefined) {
-            throwParamNotFound(param);
+            throwParamNotFound(param, type);
           }
         }
     };

--- a/lib/extra-parameters.js
+++ b/lib/extra-parameters.js
@@ -10,12 +10,14 @@ var settings = require('./settings'),
  * "body", the parameter name is superfluous since there can only be one.
  * "body" is mutually exclusive with formData/multipartFormData
  *
- * @param  {Object} requestParams     - { formData: hash, body: string }
+ * @param  {Object} requestBody
  * @param  {Object} pathSpecParamHash - subset of swagger file for this path
  * @return {Boolean} found - true when variable mentioned in file, false if unmentioned
  */
-function handleBody(requestParams, specParamsByType) {
-  return specParamsByType.body !== undefined;
+function handleBody(requestBody, specParamsByType) {
+  if(requestBody && specParamsByType.body === undefined) {
+    throw new Error('Request "body" present, but Swagger spec has no body parameter mentioned')
+  };
 }
 
 function handleFormData(requestFormData, specParamsByType) {
@@ -33,18 +35,18 @@ function handleFormData(requestFormData, specParamsByType) {
   }
 }
 
-function handleMultipartFormData(requestFormData, specParamsByType) {
+function handleMultipartFormData(multipartFormData, specParamsByType) {
   var found = false;
   specParamsByType.formData.forEach(function(formSpecParameter) {
     if(formSpecParameter.type == 'file') {
       var regex = new RegExp('name=\\\\"'+formSpecParameter.name+'\\\\"');
-      if(requestFormData.body.match(regex)) {
+      if(!multipartFormData || multipartFormData.match(regex)) {
         found = true;
       }
     }
   });
   if(!found) {
-    throwParamNotFound(requestFormData.requestParams.multipartFormData.body);
+    throwParamNotFound(multipartFormData);
   }
 }
 
@@ -68,22 +70,19 @@ module.exports = function validateNoExtraParams(pathSpec, requestParams) {
     );
   }
 
-  var specParamsByName = pathSpec.parameters.reduce(function(hash, param) {
-    hash[param.name] = param;
-    return hash;
+  var specParamsByName = {}, specParamsByType = {};
+  pathSpec.parameters.forEach(function(param) {
+    if(!specParamsByType[param.in]) specParamsByType[param.in] = [];
+    specParamsByType[param.in].push(param);
+    specParamsByName[param.name] = param;
   }, {});
-  var specParamsByType = pathSpec.parameters.reduce(function(hash, param) {
-    if(!hash[param.in]) hash[param.in] = [];
-    hash[param.in].push(param);
-    return hash;
-  }, {});
+
   for(var type in requestParams) {
     var parameterInSwagger;
     if(type == 'header' && settings.get('errorOnExtraHeaderParameters') === false) continue;
     switch(type) {
       case 'body':
-        parameterInSwagger = handleBody(requestParams, specParamsByType);
-        if(!parameterInSwagger) throwParamNotFound(requestParams[type]);
+        handleBody(requestParams.body, specParamsByType);
         break;
       case 'formData':
         handleFormData(requestParams.formData, specParamsByType);

--- a/lib/extra-parameters.js
+++ b/lib/extra-parameters.js
@@ -14,17 +14,21 @@ var settings = require('./settings'),
  * @param  {Object} pathSpecParamHash - subset of swagger file for this path
  * @return {Boolean} found - true when variable mentioned in file, false if unmentioned
  */
-function handleBody(requestBody, specParamsByType) {
-  if(requestBody && specParamsByType.body === undefined) {
+function handleBody(requestBody, specBody) {
+  if(requestBody && specBody === undefined) {
     throw new Error('Request "body" present, but Swagger spec has no body parameter mentioned')
   };
 }
 
-function handleFormData(requestFormData, specParamsByType) {
+/**
+ * Asserts that request form data variables are in Swagger. Throws if not found.
+ * @param  {Object} requestFormData - request form data(query string format) as a hash
+ * @param  {Object} requestParams - hash of request parameters
+ */
+function handleFormData(requestFormData, specFormData) {
   for(var qsKey in requestFormData) {
     var found = false;
-    specParamsByType.formData.forEach(function(formSpecParameter) {
-
+    specFormData.forEach(function(formSpecParameter) {
       if(formSpecParameter.name == qsKey && formSpecParameter.type !== 'file') {
         found = true;
       }
@@ -35,9 +39,14 @@ function handleFormData(requestFormData, specParamsByType) {
   }
 }
 
-function handleMultipartFormData(multipartFormData, specParamsByType) {
+/**
+ * Asserts that multipart file uploads are in swagger. Throws if not found.
+ * @param  {String} multipartFormData - request body
+ * @param  {Object} specParamsByType  - swagger parameters hashed by location
+ */
+function handleMultipartFormData(multipartFormData, specFormData) {
   var found = false;
-  specParamsByType.formData.forEach(function(formSpecParameter) {
+  specFormData.forEach(function(formSpecParameter) {
     if(formSpecParameter.type == 'file') {
       var regex = new RegExp('name=\\\\"'+formSpecParameter.name+'\\\\"');
       if(!multipartFormData || multipartFormData.match(regex)) {
@@ -82,13 +91,13 @@ module.exports = function validateNoExtraParams(pathSpec, requestParams) {
     if(type == 'header' && settings.get('errorOnExtraHeaderParameters') === false) continue;
     switch(type) {
       case 'body':
-        handleBody(requestParams.body, specParamsByType);
+        handleBody(requestParams.body, specParamsByType.body);
         break;
       case 'formData':
-        handleFormData(requestParams.formData, specParamsByType);
+        handleFormData(requestParams.formData, specParamsByType.formData);
         break
       case 'multipartFormData':
-        handleMultipartFormData(requestParams.multipartFormData, specParamsByType);
+        handleMultipartFormData(requestParams.multipartFormData, specParamsByType.formData);
         break;
       default:
         for(var param in requestParams[type]) {

--- a/lib/extra-parameters.js
+++ b/lib/extra-parameters.js
@@ -1,7 +1,52 @@
 'use strict';
 
 var settings = require('./settings'),
-    qs = require('qs');
+    qs = require('qs'),
+    throwParamNotFound;
+
+/**
+ * Body/FormData/MultipartFormData handling
+ *
+ * "body", the parameter name is superfluous since there can only be one.
+ * "body" is mutually exclusive with formData/multipartFormData
+ *
+ * @param  {Object} requestParams     - { formData: hash, body: string }
+ * @param  {Object} pathSpecParamHash - subset of swagger file for this path
+ * @return {Boolean} found - true when variable mentioned in file, false if unmentioned
+ */
+function handleBody(requestParams, specParamsByType) {
+  return specParamsByType.body !== undefined;
+}
+
+function handleFormData(requestFormData, specParamsByType) {
+  for(var qsKey in requestFormData) {
+    var found = false;
+    specParamsByType.formData.forEach(function(formSpecParameter) {
+
+      if(formSpecParameter.name == qsKey && formSpecParameter.type !== 'file') {
+        found = true;
+      }
+    })
+    if(!found) {
+      throwParamNotFound(qsKey);
+    }
+  }
+}
+
+function handleMultipartFormData(requestFormData, specParamsByType) {
+  var found = false;
+  specParamsByType.formData.forEach(function(formSpecParameter) {
+    if(formSpecParameter.type == 'file') {
+      var regex = new RegExp('name=\\\\"'+formSpecParameter.name+'\\\\"');
+      if(requestFormData.body.match(regex)) {
+        found = true;
+      }
+    }
+  });
+  if(!found) {
+    throwParamNotFound(requestFormData.requestParams.multipartFormData.body);
+  }
+}
 
 /**
  * Traverses the parameters in the request and asserts that all were mentioned
@@ -15,7 +60,7 @@ var settings = require('./settings'),
 module.exports = function validateNoExtraParams(pathSpec, requestParams) {
   if(settings.get('errorOnExtraParameters') === false) return;
 
-  function throwParamNotFound(param) {
+  throwParamNotFound = function(param) {
     throw new Error('Parameter not mentioned in swagger spec: "' + param + '", available params: ' +
       pathSpec.parameters.map(function(p) {
         return p.name;
@@ -23,40 +68,35 @@ module.exports = function validateNoExtraParams(pathSpec, requestParams) {
     );
   }
 
-  var pathSpecParamHash = pathSpec.parameters.reduce(function(hash, param) {
+  var specParamsByName = pathSpec.parameters.reduce(function(hash, param) {
     hash[param.name] = param;
     return hash;
   }, {});
+  var specParamsByType = pathSpec.parameters.reduce(function(hash, param) {
+    if(!hash[param.in]) hash[param.in] = [];
+    hash[param.in].push(param);
+    return hash;
+  }, {});
   for(var type in requestParams) {
+    var parameterInSwagger;
     if(type == 'header' && settings.get('errorOnExtraHeaderParameters') === false) continue;
-
-    for(var param in requestParams[type]) {
-      if(['body', 'formData', 'multipartFormData'].indexOf(param) != -1) {
-        //in the case of "body", the name superfluous & since there can only be one,
-        //it just needs to mentioned anywhere in the swagger file
-        var found = false;
-        for(var paramName in pathSpecParamHash) {
-          if(pathSpecParamHash[paramName].in == 'body') {
-            found = true;
-            break;
+    switch(type) {
+      case 'body':
+        parameterInSwagger = handleBody(requestParams, specParamsByType);
+        if(!parameterInSwagger) throwParamNotFound(requestParams[type]);
+        break;
+      case 'formData':
+        handleFormData(requestParams.formData, specParamsByType);
+        break
+      case 'multipartFormData':
+        handleMultipartFormData(requestParams.multipartFormData, specParamsByType);
+        break;
+      default:
+        for(var param in requestParams[type]) {
+          if(specParamsByName[param] === undefined) {
+            throwParamNotFound(param);
           }
-          if(pathSpecParamHash[paramName].in == 'formData') {
-            if(pathSpecParamHash[paramName].type == 'file') {
-              var regex = new RegExp('name=\\\\"'+pathSpecParamHash[paramName].name+'\\\\"');
-              if(requestParams.multipartFormData.body.match(regex)) {
-                found = true;
-                break;
-              }
-            } else if(requestParams.formData.hasOwnProperty(paramName)) {
-              found = true;
-              break;
-            }
-          }
-        };
-        if(!found) throwParamNotFound(param);
-      } else if(!pathSpecParamHash[param]) {
-        throwParamNotFound(param);
-      }
+        }
     };
   };
-}
+};

--- a/lib/extra-parameters.js
+++ b/lib/extra-parameters.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var settings = require('./settings');
+var settings = require('./settings'),
+    qs = require('qs');
 
 /**
  * Traverses the parameters in the request and asserts that all were mentioned
@@ -27,17 +28,29 @@ module.exports = function validateNoExtraParams(pathSpec, requestParams) {
     return hash;
   }, {});
   for(var type in requestParams) {
-    if(type == 'header' && settings.get('errorOnExtraHeaderParameters') === false) return;
+    if(type == 'header' && settings.get('errorOnExtraHeaderParameters') === false) continue;
 
     for(var param in requestParams[type]) {
-      if(param == 'body') {
+      if(['body', 'formData', 'multipartFormData'].indexOf(param) != -1) {
         //in the case of "body", the name superfluous & since there can only be one,
         //it just needs to mentioned anywhere in the swagger file
         var found = false;
-        for(var prop in pathSpecParamHash) {
-          if(pathSpecParamHash[prop].in == 'body') {
+        for(var paramName in pathSpecParamHash) {
+          if(pathSpecParamHash[paramName].in == 'body') {
             found = true;
             break;
+          }
+          if(pathSpecParamHash[paramName].in == 'formData') {
+            if(pathSpecParamHash[paramName].type == 'file') {
+              var regex = new RegExp('name=\\\\"'+pathSpecParamHash[paramName].name+'\\\\"');
+              if(requestParams.multipartFormData.body.match(regex)) {
+                found = true;
+                break;
+              }
+            } else if(requestParams.formData.hasOwnProperty(paramName)) {
+              found = true;
+              break;
+            }
           }
         };
         if(!found) throwParamNotFound(param);

--- a/lib/hippie-swagger.js
+++ b/lib/hippie-swagger.js
@@ -5,13 +5,11 @@ var hippie = require('hippie'),
     settings = require('./settings'),
     swaggerValidator = require('./swagger-validator');
 
-//@TODOs
-//"in": "formData"
-  //" Since form parameters are sent in the payload, they cannot be declared together with a body parameter for the same operation."
-//Body - The payload that's appended to the HTTP request.
-//Since there can only be one payload, there can only be one body parameter.
-//The name of the body parameter has no effect on the parameter itself and is used for documentation purposes only.
-//Since Form parameters are also in the payload, body and form parameters cannot exist together fo
+/**
+ * Stores parameters in the url path for later substitution
+ * @param  {Object} parameters - { pathVariableName: value }
+ * @return {Object <hippie>} - current hippie instance
+ */
 hippie.prototype.pathParams = function(parameters) {
   var self = this;
   this.swaggerParams = this.swaggerParams || {};

--- a/lib/hippie-swagger.js
+++ b/lib/hippie-swagger.js
@@ -8,7 +8,10 @@ var hippie = require('hippie'),
 //@TODOs
 //"in": "formData"
   //" Since form parameters are sent in the payload, they cannot be declared together with a body parameter for the same operation."
-
+//Body - The payload that's appended to the HTTP request.
+//Since there can only be one payload, there can only be one body parameter.
+//The name of the body parameter has no effect on the parameter itself and is used for documentation purposes only.
+//Since Form parameters are also in the payload, body and form parameters cannot exist together fo
 hippie.prototype.pathParams = function(parameters) {
   var self = this;
   this.swaggerParams = this.swaggerParams || {};

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -21,12 +21,15 @@ function paramHashFromHippie(pathParams, opts) {
   }
 
   //manage body
-  if(opts.headers && opts.headers['Content-Type'].match(/application\/x-www-form-urlencoded/)) {
-    params.formData = qs.parse(opts.body);
-  } else if(opts.headers && opts.headers['Content-Type'].match(/multipart\/form-data/)) {
-    params.multipartFormData = { body: opts.body };
-  } else if(opts.body) {
-    params.body = { body: opts.body }; //fixme
+  if(opts.headers && opts.headers['Content-Type']) {
+    if(opts.headers['Content-Type'].match(/application\/x-www-form-urlencoded/)) {
+      params.formData = qs.parse(opts.body);
+    } else if(opts.headers['Content-Type'].match(/multipart\/form-data/)) {
+      params.multipartFormData = opts.body;
+    }
+  }
+  if(opts.body && !params.formData && !params.multipartFormData) {
+    params.body = opts.body;
   }
 
   if(opts.qs) {
@@ -86,7 +89,7 @@ module.exports = function parameters(pathSpec, options, pathParams) {
 
     if(paramSchema.in === 'body') {
       paramSchema = paramSchema.schema; //"body" params are nested under schema
-      paramValue = JSON.parse(requestParams[param.in].body);
+      paramValue = JSON.parse(requestParams[param.in]);
     } else {
       paramValue = requestParams[param.in][param.name]
       //delete all the non-json-schema(swagger specific) properties, which will cause an invalid schema

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -13,8 +13,8 @@ var ajv = require('ajv')(),
  * @param  {Hash} opts - hippie options
  * @return {Hash} parameters by location
  */
-function buildParamHashFromOptions(params, opts) {
-  var params = params || {};
+function paramHashFromHippie(pathParams, opts) {
+  var params = objectAssign({}, pathParams);
   if(opts.body) {
     params.body = { body: opts.body };
   }
@@ -33,15 +33,15 @@ function buildParamHashFromOptions(params, opts) {
  * @param  {Object} options - hippie-provided hash describing the request about to be made
  * @param  {Object} parameters - hash of path parameters, added via pathParams()
  */
-module.exports = function parameters(pathSpec, options, parameters) {
+module.exports = function parameters(pathSpec, options, pathParams) {
   /**
    * Replaces variables mentioned in the request uri with what was specified by pathParams()
    * @param  {Any} param - parameter to inject into the uri
    */
-  function replacePathParams(param) {
+  function replacePathParams(param, requestParams) {
     if(param.in == 'path') {
       var regex = new RegExp('{' + param.name + '}', 'g');
-      options.url = options.url.replace(regex, parameters[param.in][param.name]);
+      options.url = options.url.replace(regex, requestParams[param.in][param.name]);
     }
   }
 
@@ -50,9 +50,9 @@ module.exports = function parameters(pathSpec, options, parameters) {
    * in the request
    * @param  {Any} param - parameter to assert
    */
-  function validateRequiredParams(param) {
-    if((parameters[param.in] === undefined ||
-       parameters[param.in][param.name] === undefined) && param.required) {
+  function validateRequiredParams(param, requestParams) {
+    if((requestParams[param.in] === undefined ||
+       requestParams[param.in][param.name] === undefined) && param.required) {
         throw new Error('Missing required parameter in ' + param.in + ': ' + param.name);
     }
   }
@@ -61,13 +61,13 @@ module.exports = function parameters(pathSpec, options, parameters) {
    * Validates each parameter against the swagger definition
    * @param  {Any} param - request parameter to be validated
    */
-  function validateParamSchema(param) {
+  function validateParamSchema(param, requestParams) {
     if(settings.get('validateParameterSchema') === false) return;
 
-    if(!parameters[param.in] || !parameters[param.in][param.name]) return;
+    if(!requestParams[param.in] || !requestParams[param.in][param.name]) return;
 
     var paramSchema = objectAssign({}, param),
-        paramValue = parameters[param.in][param.name];
+        paramValue = requestParams[param.in][param.name];
 
     if(paramSchema.in === 'body') {
       //"body" params are nested under schema
@@ -82,19 +82,18 @@ module.exports = function parameters(pathSpec, options, parameters) {
     }
 
     if(!ajv.validate(paramSchema, paramValue)) {
-      throw new Error('Invalid format for parameter {' + param.name + '}, received: ' + parameters[param.in][param.name] + '.  errors:' + ajv.errorsText());
+      throw new Error('Invalid format for parameter {' + param.name + '}, received: ' + requestParams[param.in][param.name] + '.  errors:' + ajv.errorsText());
     }
   }
-
-  parameters = buildParamHashFromOptions(parameters, options);
+  var requestParams = paramHashFromHippie(pathParams, options);
   pathSpec.parameters = pathSpec.parameters || [];
 
-  validateNoExtraParams(pathSpec, parameters);
+  validateNoExtraParams(pathSpec, requestParams);
 
   pathSpec.parameters.forEach(function(param) {
-    validateRequiredParams(param);
-    validateParamSchema(param);
-    replacePathParams(param);
+    validateRequiredParams(param, requestParams);
+    validateParamSchema(param, requestParams);
+    replacePathParams(param, requestParams);
   });
   return options;
 }

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -81,9 +81,8 @@ module.exports = function parameters(pathSpec, options, pathParams) {
    */
   function validateParamSchema(param, requestParams) {
     if(settings.get('validateParameterSchema') === false) return;
-    if(!requestParams[param.in] ||
-       (!requestParams[param.in][param.name] && param.in !== 'body')) return;
-//todo move return check into conditional below
+    if(!requestParams[param.in]) return;
+
     var paramSchema = objectAssign({}, param);
     var paramValue;
 
@@ -91,7 +90,9 @@ module.exports = function parameters(pathSpec, options, pathParams) {
       paramSchema = paramSchema.schema; //"body" params are nested under schema
       paramValue = JSON.parse(requestParams[param.in]);
     } else {
-      paramValue = requestParams[param.in][param.name]
+      paramValue = requestParams[param.in][param.name];
+      if(!paramValue) return;
+
       //delete all the non-json-schema(swagger specific) properties, which will cause an invalid schema
       delete paramSchema.in;
       delete paramSchema.description;

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -2,6 +2,7 @@
 
 var ajv = require('ajv')(),
     settings = require('./settings'),
+    qs = require('qs'),
     validateNoExtraParams = require('./extra-parameters'),
     objectAssign = require('object-assign');
 
@@ -14,13 +15,23 @@ var ajv = require('ajv')(),
  * @return {Hash} parameters by location
  */
 function paramHashFromHippie(pathParams, opts) {
-  var params = objectAssign({}, pathParams);
-  if(opts.body) {
-    params.body = { body: opts.body };
-  }
+  var params = objectAssign({
+    formData: {},
+    multipartFormData: {}
+  }, pathParams);
   if(opts.headers) {
     params.header = objectAssign({}, opts.headers);
   }
+
+  //manage body
+  if(opts.headers && opts.headers['Content-Type'].match(/application\/x-www-form-urlencoded/)) {
+    params.formData = qs.parse(opts.body);
+  } else if(opts.headers && opts.headers['Content-Type'].match(/multipart\/form-data/)) {
+    params.multipartFormData = { body: opts.body };
+  } else if(opts.body) {
+    params.body = { body: opts.body };
+  }
+
   if(opts.qs) {
     params.query = objectAssign({}, opts.qs);
   }
@@ -72,7 +83,7 @@ module.exports = function parameters(pathSpec, options, pathParams) {
     if(settings.get('validateParameterSchema') === false) return;
     if(!requestParams[param.in] ||
        (!requestParams[param.in][param.name] && param.in !== 'body')) return;
-
+//todo move return check into conditional below
     var paramSchema = objectAssign({}, param);
     var paramValue;
 

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -15,10 +15,7 @@ var ajv = require('ajv')(),
  * @return {Hash} parameters by location
  */
 function paramHashFromHippie(pathParams, opts) {
-  var params = objectAssign({
-    formData: {},
-    multipartFormData: {}
-  }, pathParams);
+  var params = objectAssign({}, pathParams);
   if(opts.headers) {
     params.header = objectAssign({}, opts.headers);
   }
@@ -29,7 +26,7 @@ function paramHashFromHippie(pathParams, opts) {
   } else if(opts.headers && opts.headers['Content-Type'].match(/multipart\/form-data/)) {
     params.multipartFormData = { body: opts.body };
   } else if(opts.body) {
-    params.body = { body: opts.body };
+    params.body = { body: opts.body }; //fixme
   }
 
   if(opts.qs) {

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -26,6 +26,9 @@ function paramHashFromHippie(pathParams, opts) {
   }
   return params;
 }
+function throwMissingRequiredParameter(param) {
+  throw new Error('Missing required parameter in ' + param.in + ': ' + param.name);
+}
 
 /**
  * Hippie middleware that validates parameters prior to request
@@ -51,9 +54,13 @@ module.exports = function parameters(pathSpec, options, pathParams) {
    * @param  {Any} param - parameter to assert
    */
   function validateRequiredParams(param, requestParams) {
-    if((requestParams[param.in] === undefined ||
-       requestParams[param.in][param.name] === undefined) && param.required) {
-        throw new Error('Missing required parameter in ' + param.in + ': ' + param.name);
+    if(param.required) {
+      if(param.in == 'body') { //There can only be one body parameter, and naming is irrelevant
+        if(!requestParams[param.in]) throwMissingRequiredParameter(param);
+      } else if((requestParams[param.in] === undefined ||
+         requestParams[param.in][param.name] === undefined)) {
+          throwMissingRequiredParameter(param);
+      }
     }
   }
 
@@ -63,17 +70,17 @@ module.exports = function parameters(pathSpec, options, pathParams) {
    */
   function validateParamSchema(param, requestParams) {
     if(settings.get('validateParameterSchema') === false) return;
+    if(!requestParams[param.in] ||
+       (!requestParams[param.in][param.name] && param.in !== 'body')) return;
 
-    if(!requestParams[param.in] || !requestParams[param.in][param.name]) return;
-
-    var paramSchema = objectAssign({}, param),
-        paramValue = requestParams[param.in][param.name];
+    var paramSchema = objectAssign({}, param);
+    var paramValue;
 
     if(paramSchema.in === 'body') {
-      //"body" params are nested under schema
-      paramSchema = paramSchema.schema;
-      paramValue = JSON.parse(paramValue);
+      paramSchema = paramSchema.schema; //"body" params are nested under schema
+      paramValue = JSON.parse(requestParams[param.in].body);
     } else {
+      paramValue = requestParams[param.in][param.name]
       //delete all the non-json-schema(swagger specific) properties, which will cause an invalid schema
       delete paramSchema.in;
       delete paramSchema.description;

--- a/lib/response.js
+++ b/lib/response.js
@@ -14,7 +14,7 @@ var ajv = require('ajv')(),
  * @param  {Object} schema - json schema
  */
 function validateBody(res, body, schema) {
-  if(settings.get('validateResponseSchema') === false) return;
+  if(!body || settings.get('validateResponseSchema') === false) return;
 
   if(schema) {
     if(!ajv.validate(schema, body)) {
@@ -40,7 +40,6 @@ function validateStatusCode(res, statusCode) {
 
 module.exports = function response(pathSpec, res, body, next) {
   var statusCode = pathSpec.responses[res.statusCode];
-
   try {
     validateStatusCode(res, statusCode);
     validateBody(res, body, statusCode.schema);

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "dependencies": {
     "ajv": "^1.0.0",
-    "object-assign": "^3.0.0"
+    "object-assign": "^3.0.0",
+    "qs": "^5.2.0"
   },
   "devDependencies": {
     "chai": "^3.2.0",

--- a/test/extra-parameters.test.js
+++ b/test/extra-parameters.test.js
@@ -7,7 +7,7 @@ describe('extra parameters', function() {
       .get('/foos')
       .pathParams({ unmentionedParam: 50 })
       .end();
-    }).to.throw(/Parameter not mentioned in swagger spec: "unmentionedParam"/);
+    }).to.throw(/path parameter not mentioned in swagger spec: "unmentionedParam"/);
   });
 
   describe('formData', function() {
@@ -18,7 +18,7 @@ describe('extra parameters', function() {
         .form()
         .send({unmentionedParam1: 'nothing', unmentionedParam2: 'nothing'})
         .end();
-      }).to.throw(/Parameter not mentioned in swagger spec: "unmentionedParam1"/);
+      }).to.throw(/formData parameter not mentioned in swagger spec: "unmentionedParam1"/);
     });
 
     it('errors on formData file parameters not mentioned in the swagger spec', function() {
@@ -30,7 +30,7 @@ describe('extra parameters', function() {
         .send(file)
         .get('/foos')
         .end();
-      }).to.throw(/Parameter not mentioned in swagger spec: ""Content-Disposition/);
+      }).to.throw(/formData \(expected type "file"\) parameter not mentioned in swagger spec: ""Content-Disposition/);
     });
   })
 
@@ -59,7 +59,7 @@ describe('extra parameters', function() {
         .header("X-New-Header", 1)
         .get('/foos')
         .end();
-      }).to.throw(/Parameter not mentioned in swagger spec:/)
+      }).to.throw(/header parameter not mentioned in swagger spec:/)
     });
   });
 

--- a/test/extra-parameters.test.js
+++ b/test/extra-parameters.test.js
@@ -1,13 +1,23 @@
 'use strict';
 
 describe('extra parameters', function() {
-  it('errors on parameters not mentioned in the swagger spec', function() {
+  it('errors on path parameters not mentioned in the swagger spec', function() {
     expect(function() {
       hippie(app, swaggerSchema)
       .get('/foos')
-      .pathParams({ asdf: 50 })
+      .pathParams({ unmentionedParam: 50 })
       .end();
-    }).to.throw(/Parameter not mentioned in swagger spec: "asdf"/);
+    }).to.throw(/Parameter not mentioned in swagger spec: "unmentionedParam"/);
+  });
+
+  it('errors on formData parameters not mentioned in the swagger spec', function() {
+    expect(function() {
+      hippie(app, swaggerSchema)
+      .get('/foos')
+      .form()
+      .send({unmentionedParam1: 'nothing', unmentionedParam2: 'nothing'})
+      .end();
+    }).to.throw(/Parameter not mentioned in swagger spec: "unmentionedParam1"/);
   });
 
   describe('header parameters', function() {

--- a/test/extra-parameters.test.js
+++ b/test/extra-parameters.test.js
@@ -10,14 +10,37 @@ describe('extra parameters', function() {
     }).to.throw(/Parameter not mentioned in swagger spec: "unmentionedParam"/);
   });
 
-  it('errors on formData parameters not mentioned in the swagger spec', function() {
+  describe('formData', function() {
+    it('errors on formData parameters not mentioned in the swagger spec', function() {
+      expect(function() {
+        hippie(app, swaggerSchema)
+        .get('/foos')
+        .form()
+        .send({unmentionedParam1: 'nothing', unmentionedParam2: 'nothing'})
+        .end();
+      }).to.throw(/Parameter not mentioned in swagger spec: "unmentionedParam1"/);
+    });
+
+    it('errors on formData file parameters not mentioned in the swagger spec', function() {
+      var file = 'Content-Disposition: form-data; name="uploadedFile"';
+
+      expect(function() {
+        hippie(app, swaggerSchema)
+        .header('Content-Type','multipart/form-data')
+        .send(file)
+        .get('/foos')
+        .end();
+      }).to.throw(/Parameter not mentioned in swagger spec: ""Content-Disposition/);
+    });
+  })
+
+  it('errors on body parameters not mentioned in the swagger spec', function() {
     expect(function() {
       hippie(app, swaggerSchema)
       .get('/foos')
-      .form()
-      .send({unmentionedParam1: 'nothing', unmentionedParam2: 'nothing'})
+      .send({unmentionedParam1: 'nothing'})
       .end();
-    }).to.throw(/Parameter not mentioned in swagger spec: "unmentionedParam1"/);
+    }).to.throw(/Request "body" present, but Swagger spec has no body parameter mentioned/);
   });
 
   describe('header parameters', function() {

--- a/test/parameters.test.js
+++ b/test/parameters.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-describe('url parameters', function() {
+describe('parameters', function() {
   it('ignores optional parameters that are missing', function(done) {
     hippie(app, swaggerSchema)
     .get('/foos')
@@ -33,8 +33,7 @@ describe('url parameters', function() {
 
   describe('header variables', function() {
     it('errors if the header is required', function() {
-      var objectAssign = require('object-assign'),
-          headerSchema = objectAssign({}, swaggerSchema);
+      var headerSchema = cloneSwagger(swaggerSchema);
 
       //set X-Total-Count to be required for this test
       headerSchema["paths"]["/foos"]["get"]["parameters"].filter(function(param) {
@@ -58,6 +57,62 @@ describe('url parameters', function() {
         expect(res.request.headers["X-Total-Count"]).to.equal(1);
         done();
       });
+    });
+  });
+
+  describe('forms', function() {
+    describe('form-data', function() {
+      it('works if formData is set to type "file"', function(done) {
+        var file = 'Content-Disposition: form-data; name="uploadedFile"';
+
+        hippie(app, swaggerSchema)
+        .header('Content-Type','multipart/form-data')
+        .send(file)
+        .post('/foos/{fooId}')
+        .pathParams({ fooId:data.firstFoo.id })
+        .end(done);
+      });
+    })
+
+    describe('urlencoded', function() {
+      it('works if formData is optional', function(done) {
+        hippie(app, swaggerSchema)
+        .form()
+        .send({ formMetadata: 'formMetadataValue' })
+        .get('/foos')
+        .end(done);
+      });
+
+      it('works if formData is required & present', function(done) {
+        var formSchema = cloneSwagger(swaggerSchema);
+
+        //set parameter to be required for this test
+        formSchema["paths"]["/foos"]["get"]["parameters"].filter(function(param) {
+          return param.name == 'formMetadata';
+        })[0]["required"] = true;
+
+        hippie(app, formSchema)
+        .form()
+        .send({ formMetadata: 'formMetadataValue' })
+        .get('/foos')
+        .end(done);
+      });
+
+      it('errors if formData is required & missing', function() {
+        var formSchema = cloneSwagger(swaggerSchema)
+
+        //set parameter to be required for this test
+        formSchema["paths"]["/foos"]["get"]["parameters"].filter(function(param) {
+          return param.name == 'formMetadata';
+        })[0]["required"] = true;
+
+        expect(function() {
+          hippie(app, formSchema)
+          .form()
+          .get('/foos')
+          .end();
+        }).to.throw(/Missing required parameter in formData: formMetadata/)
+      })
     });
   });
 

--- a/test/parameters.test.js
+++ b/test/parameters.test.js
@@ -72,21 +72,49 @@ describe('parameters', function() {
         .pathParams({ fooId:data.firstFoo.id })
         .end(done);
       });
+
+      describe('required file', function() {
+        var formSchema;
+        before(function() {
+          formSchema = cloneSwagger(swaggerSchema)
+          //set parameter to be required for this test
+          formSchema["paths"]["/foos/{fooId}"]["post"]["parameters"].filter(function(param) {
+            return param.name == 'uploadedFile';
+          })[0]["required"] = true;
+        });
+
+        it('errors if file is required & missing header and body', function() {
+          expect(function() {
+            hippie(app, formSchema)
+            .post('/foos/{fooId}')
+            .pathParams({ fooId:data.firstFoo.id })
+            .end()
+          }).to.throw(/Missing required parameter in formData: uploadedFile/)
+        })
+
+        it('errors if file is required & missing body', function() {
+          expect(function() {
+            hippie(app, formSchema)
+            .header('Content-Type','multipart/form-data')
+            .post('/foos/{fooId}')
+            .pathParams({ fooId:data.firstFoo.id })
+            .end()
+          }).to.throw(/Missing required parameter in formData: uploadedFile/)
+        })
+      })
     })
 
     describe('urlencoded', function() {
-      it('works if formData is optional', function(done) {
+      it('works if formData is optional & not provided', function(done) {
         hippie(app, swaggerSchema)
         .form()
-        .send({ formMetadata: 'formMetadataValue' })
         .get('/foos')
         .end(done);
       });
 
       it('works if formData is required & present', function(done) {
+        //set formMetadata to be required for this test
         var formSchema = cloneSwagger(swaggerSchema);
-
-        //set parameter to be required for this test
         formSchema["paths"]["/foos"]["get"]["parameters"].filter(function(param) {
           return param.name == 'formMetadata';
         })[0]["required"] = true;

--- a/test/support/bootstrap.js
+++ b/test/support/bootstrap.js
@@ -7,6 +7,9 @@ global.expect = require('chai').expect;
 global.data = require('./data');
 global.app = require('./server');
 global.hippie = require('../../index');
+global.cloneSwagger = function(swagger) {
+  return JSON.parse(JSON.stringify(swagger));
+}
 
 swaggerParser.dereference(swaggerSpec, function(err, api, metadata) {
   if(err) {

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -25,6 +25,9 @@ app.get('/foos/:fooId', function(req, res) {
 app.delete('/foos/:fooId', function(req, res) {
   res.status(204).end();
 });
+app.post('/foos/:fooId', function(req, res) {
+  res.status(201).end();
+});
 
 app.post('/foos', function(req, res) {
   res.send(req.body);

--- a/test/support/swagger.js
+++ b/test/support/swagger.js
@@ -30,6 +30,12 @@ module.exports = {
           "description": "header example",
           "required": false,
           "type": "number",
+        },{
+          "name": "formMetadata",
+          "in": "formData",
+          "description": "Additional data to pass to server",
+          "required": false,
+          "type": "string",
         }],
         "responses": {
           "200": {
@@ -136,6 +142,31 @@ module.exports = {
             }
           }
         }
+      },
+      "post": {
+        "description": "Upload file example",
+        consumes: [
+          "multipart/form-data"
+        ],
+        "responses": {
+          "201": {
+            "description": "noop"
+          },
+        },
+        "parameters": [{
+          "name": "fooId",
+          "in": "path",
+          "description": "foo identifier",
+          "required": true,
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$"
+        },{
+          "in": "formData",
+          "name": "uploadedFile",
+          "type": "file",
+          "description": "file upload",
+          "required": false
+        }],
       },
       "delete": {
         "description": "Deleting a foo",

--- a/test/support/swagger.js
+++ b/test/support/swagger.js
@@ -47,7 +47,8 @@ module.exports = {
         "description": "Create a foo",
         "parameters": [{
           "in": "body",
-          "name": "body",
+          //Swagger spec: "The name of the body parameter has no effect on the parameter itself"
+          "name": "name-irrelevant",
           "description": "foo object to be added",
           "required": true,
           "schema": {


### PR DESCRIPTION
- Adds functionality for the final parameter type that was not supported: {in: "formData"}
- Bugfix where if errorOnExtraHeaderParameters was on, extranous parameters in other locations would not be detected.