### PR TITLE
Update ajv version to fix issue with npm 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "hippie": "*"
   },
   "dependencies": {
-    "ajv": "^1.0.0",
+    "ajv": "^4.1.0",
     "object-assign": "^3.0.0",
     "qs": "^5.2.0",
     "string.prototype.startswith": "^0.2.0"


### PR DESCRIPTION
When using npm 3 peer dependencies are not installed. As a consequence ajv-i18N which is required by ajv 1.x is not installed.