### PR TITLE
Stelau/fix base path slash

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -17,6 +17,7 @@ function middleware (swaggerDef, options, next) {
 
     // remove basePath before searching path into swagger paths
     path = path.replace(swaggerDef.basePath, '')
+    path = path === '' ? '/' : path
   }
 
   if (!swaggerDef.paths[path]) {

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -61,6 +61,18 @@ describe('middleware', function () {
       })
     })
 
+    it('basePath is set and subpath is /', function () {
+      var originalSwaggerSchema = swaggerSchema.basePath
+      var basePathOptions = {method: 'GET', url: '/'}
+      swaggerSchema.basePath = '/base'
+      ctx._url = '/base'
+
+      middleware.call(ctx, swaggerSchema, basePathOptions, function (opts) {
+        expect(opts).to.eql(basePathOptions)
+      })
+      swaggerSchema.basePath = originalSwaggerSchema
+    })
+
     it('basePath is set but equal to /', function () {
       swaggerSchema.basePath = '/'
       ctx._url = '/foos'

--- a/test/support/swagger.js
+++ b/test/support/swagger.js
@@ -7,6 +7,22 @@ module.exports = {
     'title': 'Test App'
   },
   'paths': {
+    '/': {
+      'get': {
+        'description': 'List foos from base path',
+        'responses': {
+          '200': {
+            'description': 'Successful response',
+            'schema': {
+              'type': 'array',
+              'items': {
+                '$ref': '#/definitions/foo'
+              }
+            }
+          }
+        }
+      }
+    },
     '/foos': {
       'get': {
         'description': 'List all foos',


### PR DESCRIPTION
I've noticed if you have a basepath something like `/base` and then you have a subpath of `/` you're not able to address this directly from the tests even though its valid.

What this means:
Tests like this will fail:
```
    it('Should return an empty array', done => {
        hippie(app, dereferencedSwagger)
            .get('/base')
            .expectStatus(200)
            .expectBody([])
            .end(done);
    });
``` 

While tests like this will pass:
```
    it('Should return an empty array', done => {
        hippie(app, dereferencedSwagger)
            .get('/base/')
            .expectStatus(200)
            .expectBody([])
            .end(done);
    });
``` 

This PR addresses that.

On an interesting note:
The tests can fail depending on the order they're called.  This is because the swaggerSchema is global.  Currently the only reason the basepath tests don't break anything is because swaggerSchema happened to be returned to normal by the last test.  That's why this new test returns it to the original state... Open to suggestions, if you wish it this way or to just depend on that last test to return it to a good state... 
