### PR TITLE
Fix "integers in formData"-problem / add type-coercion

### DIFF
--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var ajv = require('ajv')()
+var ajv = require('ajv')({coerceTypes: ['number', 'boolean']})
 var settings = require('./settings')
 var qs = require('qs')
 var validateNoExtraParams = require('./extra-parameters')

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Hippie wrapper that provides end to end API testing with swagger validation",
   "main": "index.js",
   "scripts": {
-    "test": "mocha && npm run lint",
-    "lint": "standard"
+    "test": "./node_modules/mocha/bin/mocha && npm run lint",
+    "lint": "./node_modukes/standard/bin/cmd.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha && npm run lint",
-    "lint": "./node_modukes/standard/bin/cmd.js"
+    "lint": "node ./node_modules/standard/bin/cmd.js"
   },
   "repository": {
     "type": "git",

--- a/test/parameters.test.js
+++ b/test/parameters.test.js
@@ -173,15 +173,14 @@ describe('parameters', function () {
       })
 
       it('when requesting with non-integer values, validation is rejected', function (done) {
-        try {
-          hippie(app, swaggerSchema)
-            .del('/integerTest/{fooId}')
-            .pathParams({fooId: '137'})
-            .end(done)
-        } catch (e) {
-          expect(e).to.match(/Invalid format for parameter {fooId}/)
-          done()
-        }
+        hippie(app, swaggerSchema)
+          .del('/integerTest/{fooId}')
+          .pathParams({fooId: 'c'})
+          .end()
+          .catch(function (err) {
+            expect(err).to.match(/Invalid format for parameter {fooId}/)
+            done()
+          })
       })
     })
 
@@ -198,35 +197,33 @@ describe('parameters', function () {
       })
 
       it('when sending non-integer values in path, validation is rejected', function (done) {
-        try {
-          hippie(app, swaggerSchema)
-            .form()
-            .send({
-              barId: 1
-            })
-            .post('/integerTest/{fooId}')
-            .pathParams({fooId: '137'})
-            .end(done)
-        } catch (e) {
-          expect(e).to.match(/Invalid format for parameter {fooId}/)
-          done()
-        }
+        hippie(app, swaggerSchema)
+          .form()
+          .send({
+            barId: 1
+          })
+          .post('/integerTest/{fooId}')
+          .pathParams({fooId: 'c'})
+          .end()
+          .catch(function (err) {
+            expect(err).to.match(/Invalid format for parameter {fooId}/)
+            done()
+          })
       })
 
       it('when sending non-integer values in formData, validation is rejected', function (done) {
-        try {
-          hippie(app, swaggerSchema)
-            .form()
-            .send({
-              barId: '1'
-            })
-            .post('/integerTest/{fooId}')
-            .pathParams({fooId: 137})
-            .end(done)
-        } catch (e) {
-          expect(e).to.match(/Invalid format for parameter {barId}/)
-          done()
-        }
+        hippie(app, swaggerSchema)
+          .form()
+          .send({
+            barId: 'c'
+          })
+          .post('/integerTest/{fooId}')
+          .pathParams({fooId: 137})
+          .end()
+          .catch(function (err) {
+            expect(err).to.match(/Invalid format for parameter {barId}/)
+            done()
+          })
       })
     })
 
@@ -243,35 +240,33 @@ describe('parameters', function () {
       })
 
       it('when sending non-integer values in path, validation is rejected', function (done) {
-        try {
-          hippie(app, swaggerSchema)
-            .form()
-            .send({
-              barId: 1
-            })
-            .patch('/integerTest/{fooId}')
-            .pathParams({fooId: '137'})
-            .end(done)
-        } catch (e) {
-          expect(e).to.match(/Invalid format for parameter {fooId}/)
-          done()
-        }
+        hippie(app, swaggerSchema)
+          .form()
+          .send({
+            barId: 1
+          })
+          .patch('/integerTest/{fooId}')
+          .pathParams({fooId: 'c'})
+          .end()
+          .catch(function (err) {
+            expect(err).to.match(/Invalid format for parameter {fooId}/)
+            done()
+          })
       })
 
       it('when sending non-integer values in formData, validation is rejected', function (done) {
-        try {
-          hippie(app, swaggerSchema)
-            .form()
-            .send({
-              barId: '1'
-            })
-            .patch('/integerTest/{fooId}')
-            .pathParams({fooId: 137})
-            .end(done)
-        } catch (e) {
-          expect(e).to.match(/Invalid format for parameter {barId}/)
-          done()
-        }
+        hippie(app, swaggerSchema)
+          .form()
+          .send({
+            barId: 'c'
+          })
+          .patch('/integerTest/{fooId}')
+          .pathParams({fooId: 137})
+          .end()
+          .catch(function (err) {
+            expect(err).to.match(/Invalid format for parameter {barId}/)
+            done()
+          })
       })
     })
   })

--- a/test/parameters.test.js
+++ b/test/parameters.test.js
@@ -132,11 +132,146 @@ describe('parameters', function () {
           return param.name === 'formMetadata'
         })[0]['required'] = true
 
-        expect(hippie(app, formSchema)
+        expect(
+          hippie(app, formSchema)
           .form()
           .get('/foos')
           .end()
         ).to.be.rejectedWith(/Missing required parameter in formData: formMetadata/)
+      })
+    })
+  })
+
+  describe('integers', function () {
+    describe('when using get', function () {
+      it('when requesting with valid integers, validation is ok', function (done) {
+        hippie(app, swaggerSchema)
+          .get('/integerTest/{fooId}')
+          .pathParams({fooId: 137})
+          .end(done)
+      })
+
+      it('when requesting with non-integer values, validation is rejected', function (done) {
+        try {
+          hippie(app, swaggerSchema)
+            .get('/integerTest/{fooId}')
+            .pathParams({fooId: '137'})
+            .end(done)
+        } catch (e) {
+          expect(e).to.match(/Invalid format for parameter {fooId}/)
+          done()
+        }
+      })
+    })
+
+    describe('when using delete', function () {
+      it('when requesting with valid integers, validation is ok', function (done) {
+        hippie(app, swaggerSchema)
+          .del('/integerTest/{fooId}')
+          .pathParams({fooId: 137})
+          .end(done)
+      })
+
+      it('when requesting with non-integer values, validation is rejected', function (done) {
+        try {
+          hippie(app, swaggerSchema)
+            .del('/integerTest/{fooId}')
+            .pathParams({fooId: '137'})
+            .end(done)
+        } catch (e) {
+          expect(e).to.match(/Invalid format for parameter {fooId}/)
+          done()
+        }
+      })
+    })
+
+    describe('when using post', function () {
+      it('when sending valid integers, validation is ok', function (done) {
+        hippie(app, swaggerSchema)
+          .form()
+          .send({
+            barId: 1
+          })
+          .post('/integerTest/{fooId}')
+          .pathParams({fooId: 137})
+          .end(done)
+      })
+
+      it('when sending non-integer values in path, validation is rejected', function (done) {
+        try {
+          hippie(app, swaggerSchema)
+            .form()
+            .send({
+              barId: 1
+            })
+            .post('/integerTest/{fooId}')
+            .pathParams({fooId: '137'})
+            .end(done)
+        } catch (e) {
+          expect(e).to.match(/Invalid format for parameter {fooId}/)
+          done()
+        }
+      })
+
+      it('when sending non-integer values in formData, validation is rejected', function (done) {
+        try {
+          hippie(app, swaggerSchema)
+            .form()
+            .send({
+              barId: '1'
+            })
+            .post('/integerTest/{fooId}')
+            .pathParams({fooId: 137})
+            .end(done)
+        } catch (e) {
+          expect(e).to.match(/Invalid format for parameter {barId}/)
+          done()
+        }
+      })
+    })
+
+    describe('when using patch', function () {
+      it('when sending valid integers, validation is ok', function (done) {
+        hippie(app, swaggerSchema)
+          .form()
+          .send({
+            barId: 1
+          })
+          .patch('/integerTest/{fooId}')
+          .pathParams({fooId: 137})
+          .end(done)
+      })
+
+      it('when sending non-integer values in path, validation is rejected', function (done) {
+        try {
+          hippie(app, swaggerSchema)
+            .form()
+            .send({
+              barId: 1
+            })
+            .patch('/integerTest/{fooId}')
+            .pathParams({fooId: '137'})
+            .end(done)
+        } catch (e) {
+          expect(e).to.match(/Invalid format for parameter {fooId}/)
+          done()
+        }
+      })
+
+      it('when sending non-integer values in formData, validation is rejected', function (done) {
+        try {
+          hippie(app, swaggerSchema)
+            .form()
+            .send({
+              barId: '1'
+            })
+            .patch('/integerTest/{fooId}')
+            .pathParams({fooId: 137})
+            .end(done)
+        } catch (e) {
+          expect(e).to.match(/Invalid format for parameter {barId}/)
+          done()
+        }
       })
     })
   })
@@ -150,7 +285,8 @@ describe('parameters', function () {
     })
 
     it('when a parameter fails json-schema validation', function () {
-      expect(hippie(app, swaggerSchema)
+      expect(
+        hippie(app, swaggerSchema)
         .get('/foos/{fooId}')
         .pathParams({ fooId: 45 })
         .end()

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -36,6 +36,20 @@ app.get('/foos', function (req, res) {
   res.send(data.foos)
 })
 
+/* /integerTest */
+app.get('/integerTest/:fooId', function (req, res) {
+  res.send({status: 'ok'})
+})
+app.patch('/integerTest/:fooId', function (req, res) {
+  res.send({status: 'ok'})
+})
+app.post('/integerTest/:fooId', function (req, res) {
+  res.status(204).end()
+})
+app.delete('/integerTest/:fooId', function (req, res) {
+  res.status(204).end()
+})
+
 /*
  * endpoints with invalid response
  */

--- a/test/support/swagger.js
+++ b/test/support/swagger.js
@@ -202,6 +202,70 @@ module.exports = {
           }
         }
       }
+    },
+    '/integerTest/{fooId}': {
+      'parameters': [{
+        'name': 'fooId',
+        'in': 'path',
+        'description': 'foo identifier',
+        'required': true,
+        'type': 'integer'
+      }],
+      'get': {
+        'description': 'get via integer',
+        'responses': {
+          '200': {
+            'description': 'Successful response',
+            'schema': {
+              '$ref': '#/definitions/simple'
+            }
+          }
+        }
+      },
+      'patch': {
+        'description': 'patch via integer',
+        'consumes': 'application/x-www-form-urlencoded',
+        'parameters': [{
+          'name': 'barId',
+          'in': 'formData',
+          'description': 'bar identifier',
+          'required': true,
+          'type': 'integer'
+        }],
+        'responses': {
+          '200': {
+            'description': 'Successful response',
+            'schema': {
+              '$ref': '#/definitions/simple'
+            }
+          }
+        }
+      },
+      'post': {
+        'description': 'post with integers',
+        'consumes': 'application/x-www-form-urlencoded',
+        'responses': {
+          '201': {
+            'description': 'noop'
+          }
+        },
+        'parameters': [{
+          'name': 'barId',
+          'in': 'formData',
+          'description': 'bar identifier',
+          'required': true,
+          'type': 'integer'
+        }]
+      },
+      'delete': {
+        'description': 'delete with integers',
+        'parameters': [],
+        'responses': {
+          '204': {
+            'description': 'Deleted. No content'
+          }
+        }
+      }
     }
   },
   'definitions': {
@@ -222,6 +286,15 @@ module.exports = {
         'orderNumber': {
           'description': 'the order index of the foo',
           'type': 'integer'
+        }
+      }
+    },
+    'simple': {
+      'type': 'object',
+      'required': ['status'],
+      'properties': {
+        'status': {
+          'type': 'string'
         }
       }
     },

--- a/test/support/swagger.js
+++ b/test/support/swagger.js
@@ -245,8 +245,8 @@ module.exports = {
         'description': 'post with integers',
         'consumes': 'application/x-www-form-urlencoded',
         'responses': {
-          '201': {
-            'description': 'noop'
+          '204': {
+            'description': 'OK'
           }
         },
         'parameters': [{


### PR DESCRIPTION
Added tests as well as a fix for https://github.com/CacheControl/hippie-swagger/issues/21

**Attention:** type-coercion may interfere with existing tests, IF they check things like "a string with an integer is not an integer". **But** those types of tests didn't make sense in the first place for any formData, query, path or header-parameter UNLESS they are somehow encoded in a type-safe manner like JSON.