### PR TITLE
allow int32/int64 types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 3.0.1 / 2017-08-04
 ==================
 
+  * Allow int32 and int64 formats
   * Upgrade dependencies
 
 3.0.0 / 2017-06-19

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var ajv = require('ajv')({coerceTypes: ['number', 'boolean']})
+var ajv = require('ajv')({coerceTypes: ['number', 'boolean'], unknownFormats: ['int32', 'int64']})
 var settings = require('./settings')
 var qs = require('qs')
 var validateNoExtraParams = require('./extra-parameters')

--- a/lib/response.js
+++ b/lib/response.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var ajv = require('ajv')()
+var ajv = require('ajv')({ unknownFormats: ['int32', 'int64'] })
 var settings = require('./settings')
 
 /**

--- a/test/parameters.test.js
+++ b/test/parameters.test.js
@@ -151,6 +151,24 @@ describe('parameters', function () {
           .end(done)
       })
 
+      describe('int32', function () {
+        it('when requesting with valid integer, validation is ok', function (done) {
+          hippie(app, swaggerSchema)
+            .get('/foos')
+            .qs({int32: 1})
+            .end(done)
+        })
+      })
+
+      describe('int64', function () {
+        it('when requesting with valid integer, validation is ok', function (done) {
+          hippie(app, swaggerSchema)
+            .get('/foos')
+            .qs({int64: 2147483647 + 1})
+            .end(done)
+        })
+      })
+
       it('when requesting with non-integer values, validation is rejected', function (done) {
         try {
           hippie(app, swaggerSchema)

--- a/test/support/swagger.js
+++ b/test/support/swagger.js
@@ -27,6 +27,20 @@ module.exports = {
       'get': {
         'description': 'List all foos',
         'parameters': [{
+          'name': 'int32',
+          'in': 'query',
+          'description': '32 bit integer',
+          'required': false,
+          'type': 'integer',
+          'format': 'int32'
+        }, {
+          'name': 'int64',
+          'in': 'query',
+          'description': '64 bit integer',
+          'required': false,
+          'type': 'integer',
+          'format': 'int64'
+        }, {
           'name': 'limit',
           'in': 'query',
           'description': 'resultset limiter for pagination',


### PR DESCRIPTION
Allows format int63 and int32 integers, e.g.
```
"property": {
  "type": "integer",
  "format": "int64"
}
```
- NOTE: Does **not** fail validation when a 64 integer is submitted for a 32 bit integer.  Format is effectively allowed but ignored for validation purposes.


fixes #24 